### PR TITLE
fix appendices reference and TOC

### DIFF
--- a/stevensThesis.tex
+++ b/stevensThesis.tex
@@ -378,8 +378,9 @@ Electronic material, such as CDs and multimedia can accompany the dissertation. 
 The reference style used for formatting the paper must be confirmed with your department and advisor. Frequently used styles are the APA (American Psychological Association), MLA (Modern Language Association) and AMA (American Medical Association) styles. Style guides and manuals are available for each style. Page headers are not to be used.
 
 \newpage
-\addcontentsline{toc}{chapter}{Appendix A}	
-
+\addcontentsline{toc}{chapter}{Appendices}	
+\addcontentsline{toc}{section}{Appendix A}	
+\noindent \textbf{Appendices} \\
 %    \chapter{Appendix A}
 \noindent \textbf{Appendix A}    %% removed \\
 \vspace{12pt}


### PR DESCRIPTION
Solicited by Doris, it has to have a word "Appendices" before the first appendix, and has to have that structure in the table of contents
